### PR TITLE
Add make target to package a stand-alone script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,7 @@ Thumbs.db
 ############################
 fu.md
 installRecords.txt
+
+# Package files #
+src/fu.zip
+fu

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
+all: package
+
 clean:
 		find . -name "*.pyc" -delete
+		rm fu
 
 install:
 		python setup.py install --record installRecords.txt
@@ -8,3 +11,9 @@ install:
 uninstall:
 		cat installRecords.txt
 		cat installRecords.txt | xargs rm -f
+
+package:
+		cd src && zip ../fu.zip fu.py lib/*.py
+		cat src/fu.head fu.zip > fu
+		chmod +x fu
+		rm fu.zip

--- a/src/fu.head
+++ b/src/fu.head
@@ -1,0 +1,33 @@
+#!/bin/sh
+# This is a self-extracting executable.
+# Execute this like any normal executable.
+# You may need to "chmod a+x" this file.
+# This is a binary ZIP file with a Python loader header.
+#
+# Bourne shell loader:
+PYTHON=$(which python 2>/dev/null)
+if [ ! -x "$PYTHON" ] ; then
+    echo "Python not found!"
+    exit 1
+fi
+exec $PYTHON -c "
+# Python loader:
+import sys, os
+if int(sys.version[0]) < 2:
+    print 'Python version 2.3 final or greater is required.'
+    print 'Your version is', sys.version
+    os._exit(1)
+major = sys.version_info[0]
+minor = sys.version_info[1]
+releaselevel = sys.version_info[3]
+if (major==2 and minor < 3) or (major==2 and minor==3 and releaselevel!='final'):
+    print 'Python version 2.3 final or greater is required.'
+    print 'Your version is', sys.version
+    os._exit(1)
+sys.path.insert(0, sys.argv[1])
+del sys.argv[0:1]
+import fu
+fu.main()
+" $0 $@
+
+# Zip file:


### PR DESCRIPTION
The 'package' target will compile fu.py and lib/fu.py into a single script 'fu'.
This can be placed in e.g. ~/bin to allow installing without root access.

For more information about this technique, see:
http://code.activestate.com/recipes/215301-binding-main-skript-and-modules-to-one-executable-/
